### PR TITLE
Read stars in build not runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dist
-feed.*
+info.json
 .cache
 node_modules

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Home for some OSS",
   "private": true,
   "scripts": {
-    "prepare": "curl https://medium.com/feed/fiverr-engineering > feed.xml && node ./scripts/getmediumarticles.js",
+    "prepare": "node ./prepare",
     "build": "parcel build src/index.pug --public-url .",
     "start": "parcel src/index.pug",
     "lint": "eslint '**/*.js'"

--- a/prepare/githubStars/index.js
+++ b/prepare/githubStars/index.js
@@ -1,0 +1,34 @@
+const { readFile } = require('fs').promises;
+const { safeLoad } = require('js-yaml');
+const request = require('../request');
+
+module.exports = async(token) => {
+    const { projects } = safeLoad(await readFile('data.yaml'));
+    const repositories = projects.map(({ reponame }) => reponame);
+
+    const results = await Promise.all(
+        repositories.map(
+            (reponame) => request(
+                `https://api.github.com/repos/fiverr/${reponame}`,
+                {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/vnd.github.v3.raw',
+                        Authorization: `token ${token}`,
+                        'User-Agent': 'fiverr/fiverr.github.io'
+                    }
+                }
+            )
+        )
+    );
+
+    const stars = results.map((result) => JSON.parse(result).stargazers_count);
+
+    return {
+        stars: Object.assign(
+            ...repositories.map(
+                (reponame, index) => ({ [reponame]: stars[index] })
+            )
+        )
+    };
+};

--- a/prepare/index.js
+++ b/prepare/index.js
@@ -1,0 +1,24 @@
+const { writeFile } = require('fs').promises;
+const githubStars = require('./githubStars');
+const mediumArticles = require('./mediumArticles');
+
+(async() => {
+    const { GITHUB_API_TOKEN } = process.env;
+    if (!GITHUB_API_TOKEN) {
+        throw new Error('Missing Github token as environmant variable "GITHUB_API_TOKEN"');
+    }
+
+    const results = await Promise.all([
+        mediumArticles(),
+        githubStars()
+    ]);
+
+    writeFile(
+        'info.json',
+        JSON.stringify(
+            Object.assign(...results),
+            null,
+            2
+        )
+    );
+})();

--- a/prepare/mediumArticles/index.js
+++ b/prepare/mediumArticles/index.js
@@ -1,17 +1,11 @@
-const { readFile, writeFile } = require('fs').promises;
 const { xml2json } = require('xml-js');
+const request = require('../request');
 
-(async() => {
-
-    const xml = await readFile('feed.xml');
+module.exports = async() => {
+    const xml = await request('https://medium.com/feed/fiverr-engineering');
     const feed = JSON.parse(xml2json(xml));
-    const articles = extract(feed);
-
-    writeFile(
-        'feed.json',
-        JSON.stringify(articles, null, 2)
-    );
-})();
+    return { articles: extract(feed) };
+};
 
 const extract = ({ elements: [ { elements: [ { elements } ] } ] }) => elements.filter(({ name }) => name === 'item').map(pull);
 

--- a/prepare/request/index.js
+++ b/prepare/request/index.js
@@ -1,0 +1,18 @@
+const { get } = require('https');
+
+module.exports = (url, options = {}) => new Promise(
+    (resolve, reject) => get(
+        url,
+        options,
+        (result) => {
+            const data = [];
+            const { statusCode } = result;
+            if (Math.floor(statusCode / 100) !== 2) {
+                reject(`Request to ${url} resulted in status ${statusCode} (${JSON.stringify(result.headers)}).`);
+                return;
+            }
+            result.on('data', (chunk) => data.push(chunk));
+            result.on('end', () => resolve(data.join('')));
+        }
+    ).on('error', reject)
+);

--- a/src/components/Cards/index.js
+++ b/src/components/Cards/index.js
@@ -1,42 +1,17 @@
 import React from 'react';
-import { arrayOf, exact, string } from 'prop-types';
+import { arrayOf, exact, object, string } from 'prop-types';
 import Card from '../Card';
 import './index.scss';
 
-class Cards extends React.Component {
-    componentDidMount() {
-        this.props.projects.forEach(
-            ({ reponame }) => {
-                fetch(`https://api.github.com/repos/fiverr/${reponame}/stargazers`)
-                    .then((res) => res.json())
-                    .then(({ length }) => {
-                        const { stars = {} } = this.state || {};
-                        stars[reponame] = length;
-                        this.setState({ stars });
-                    });
-            }
-        );
-    }
-
-    render() {
-        const {
-            props: { projects },
-            state
-        } = this;
-
-        const { stars = {} } = state || {};
-
-        return (
-            <ul className="cards">
-                {
-                    projects.map(
-                        ({ reponame, ...project }) => <Card key={reponame} {...project} stars={stars[reponame]}/>
-                    )
-                }
-            </ul>
-        );
-    }
-}
+const Cards = ({ projects, stars }) => (
+    <ul className="cards">
+        {
+            projects.map(
+                ({ reponame, ...project }) => <Card key={reponame} {...project} stars={stars[reponame]}/>
+            )
+        }
+    </ul>
+);
 
 Cards.propTypes = {
     projects: arrayOf(exact({
@@ -45,7 +20,8 @@ Cards.propTypes = {
         reponame: string,
         language: string,
         description: string
-    }))
+    })),
+    stars: object
 };
 
 export default Cards;

--- a/src/components/Links/index.js
+++ b/src/components/Links/index.js
@@ -3,15 +3,15 @@ import { arrayOf, exact, string } from 'prop-types';
 import { rel } from '../../consts';
 import './index.scss';
 
-const Links = ({ feed, links }) => (
+const Links = ({ articles, links }) => (
     <div className="links">
         {
-            feed.length && <h2>
+            articles.length && <h2>
                 Fiverr Engineering blog
             </h2>
         }
         {
-            feed.map(
+            articles.map(
                 ({ title, link }) => (
                     <a key={link} href={link} rel={rel}>
                         { title }
@@ -38,7 +38,7 @@ const Links = ({ feed, links }) => (
 );
 
 Links.propTypes = {
-    feed: arrayOf(exact({
+    articles: arrayOf(exact({
         title: string,
         link: string
     })),

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import data from '../data.yaml';
-import feed from '../feed.json';
+import info from '../info.json';
 import Cards from './components/Cards';
 import Links from './components/Links';
 import './index.scss';
 
-ReactDOM.render(<Cards projects={data.projects}/>, document.querySelector('main'));
-ReactDOM.render(<Links feed={feed} links={data.links}/>, document.querySelector('footer'));
+ReactDOM.render(<Cards projects={data.projects} stars={info.stars}/>, document.querySelector('main'));
+ReactDOM.render(<Links articles={info.articles} links={data.links}/>, document.querySelector('footer'));


### PR DESCRIPTION
- Get stars on build instead of from the browser
- Use different API to get number of stargazers (stargazers endpoint has paging of 30, so that's the max)